### PR TITLE
COV-12 Use Liquibase for DB migrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,16 @@
 			<artifactId>sonar-jacoco-plugin</artifactId>
 			<version>1.2.0.1505</version>
 		</dependency>
+		<dependency>
+			<groupId>org.owasp</groupId>
+			<artifactId>dependency-check-maven</artifactId>
+			<version>7.4.4</version>
+			<type>maven-plugin</type>
+		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ server.port=8085
 spring.datasource.url=jdbc:mysql://localhost:3306/pro_ect_covid_api?autoreconnect=true&createDatabaseIfNotExist=true&characterEncoding=utf8
 spring.datasource.username=root
 spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.platform=initial
 spring.jpa.open-in-view=true
 spring.sql.init.mode=always

--- a/src/main/resources/db/changelog/1-create-table-country.sql
+++ b/src/main/resources/db/changelog/1-create-table-country.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `country` (
+  `id` varchar(255) NOT NULL,
+  `country_code` varchar(255) DEFAULT NULL,
+  `date` datetime DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `new_confirmed` bigint(20) DEFAULT NULL,
+  `new_deaths` bigint(20) DEFAULT NULL,
+  `new_recovered` bigint(20) DEFAULT NULL,
+  `slug` varchar(255) DEFAULT NULL,
+  `total_confirmed` bigint(20) DEFAULT NULL,
+  `total_deaths` bigint(20) DEFAULT NULL,
+  `total_recovere` bigint(20) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/changelog/2-update-country-add-primary-key.sql
+++ b/src/main/resources/db/changelog/2-update-country-add-primary-key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `country` ADD PRIMARY KEY (`id`);

--- a/src/main/resources/db/changelog/3-update-country-fix-naming.sql
+++ b/src/main/resources/db/changelog/3-update-country-fix-naming.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `country` CHANGE `total_recovere` `total_recovered` bigint(20) DEFAULT NULL

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/1-create-table-country.sql
+  - include:
+      file: db/changelog/2-update-country-add-primary-key.sql
+  - include:
+      file: db/changelog/3-update-country-fix-naming.sql


### PR DESCRIPTION
Replace DB schema generation from Hibernate with Liquibase migrations